### PR TITLE
Resizing the output messages to the right size.

### DIFF
--- a/src/nnxx/message_streambuf.hpp
+++ b/src/nnxx/message_streambuf.hpp
@@ -53,9 +53,11 @@ namespace nnxx {
   template < typename Char, typename Traits >
   message basic_message_streambuf<Char, Traits>::msg(int type)
   { message m(this->pptr() - this->pbase(), type);
-    m_msg.resize(this->pptr() - this->pbase());
-    m_msg.swap(m);
-    clear();
+
+    std::copy(reinterpret_cast<const char_type *>(this->pbase()),
+         reinterpret_cast<const char_type *>(this->pptr()),
+         reinterpret_cast<char_type *>(m.data()));
+
     return m;}
 
   template < typename Char, typename Traits >

--- a/src/nnxx/message_streambuf.hpp
+++ b/src/nnxx/message_streambuf.hpp
@@ -52,7 +52,11 @@ namespace nnxx {
 
   template < typename Char, typename Traits >
   message basic_message_streambuf<Char, Traits>::msg(int type)
-  { return copy(m_msg, this->pptr() - this->pbase(), type); }
+  { message m(this->pptr() - this->pbase(), type);
+    m_msg.resize(this->pptr() - this->pbase());
+    m_msg.swap(m);
+    clear();
+    return m;}
 
   template < typename Char, typename Traits >
   message basic_message_streambuf<Char, Traits>::move_msg()


### PR DESCRIPTION

Hello,


When a message is generated from a message_ostream, the size of the message is not changed (by default 1000).
This leads to two issues:
- an overhead during the transport
- the copy of the entire buffer used by the streambuf

The following example demonstrates the "problem":  
[example.zip](https://github.com/achille-roussel/nanomsgxx/files/141514/example.zip)
Server's side:  

```
nnxx::message_ostream os;

os << "I'm a server ";
os << getpid();

socket_.send(os.msg());
```

Client's side: 

```
m = socket_.recv();
std::cout << m.size() << " " << m << std::endl;
```


The following correction resizes the message to the right size and returns it.





```
execution summary
  tests that pass 14/14
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_message
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_message_istream
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_message_ostream
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_nnxx_ext
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_pair
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_pipeline
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_poll
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_pubsub
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_readme
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_reqrep
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_reqrep_multi
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_socket
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_survey
    /vagrant/SKNet/dep/nanomsgxx/build/tests/test_timeout
  tests that fail 0/14
```