### PR TITLE
bugfix : xsputn // taking into consideration the buffer size when copying

### DIFF
--- a/src/nnxx/message_streambuf.hpp
+++ b/src/nnxx/message_streambuf.hpp
@@ -76,14 +76,22 @@ namespace nnxx {
   basic_message_streambuf<Char, Traits>::xsputn(const char_type *s, streamsize n)
   {
     using std::copy;
+    streamsize ret = 0;
 
-    if (n > static_cast<streamsize>(this->epptr() - this->pptr())) {
-      overflow(traits_type::eof());
+    while (ret < n) {
+      streamsize buflen = static_cast<streamsize>(this->epptr() - this->pptr());
+
+      if (buflen) {
+	streamsize len = std::min(buflen, n - ret);
+	copy(s, s + len, this->pptr());
+	this->pbump(len);
+	ret += len;
+	s += len;
+      }
+      if (ret < n)
+	overflow(traits_type::eof());
     }
-
-    copy(s, s + n, this->pptr());
-    this->pbump(n);
-    return n;
+    return ret;
   }
 
   template < typename Char, typename Traits >


### PR DESCRIPTION
Hello,

I've got a memory corruption when I try to write more than 1000 bytes at once.  
```
vagrant@gitlab:~$ ./a.out
*** Error in `./a.out': free(): invalid next size (normal): 0x0000000001677400 ***
```

A snippet of code which highlights the bug:  
```c++
#include <iostream>                  
#include <nnxx/message.h>            
#include <nnxx/message_ostream.h>    
                                     
                                     
int main()                           
{                                    
  std::string str(2000, 'A');        
  nnxx::message_ostream os;          
                                     
  os << str;                         
                                     
}                                    
```

It turned out that the copy made by message_streambuf::xsputn does not take into account the available buffer size. Thereby the writes with a size higher than 1000 are not handled correctly.

I follow the [libstd++'s implementation of steambuf::xsputn](https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.0/streambuf_8tcc-source.html) to provide this patch. 


Test results:
```
execution summary
  tests that pass 14/14
    /home/vagrant/nanomsgxx/build/tests/test_readme
    /home/vagrant/nanomsgxx/build/tests/test_reqrep
    /home/vagrant/nanomsgxx/build/tests/test_pair
    /home/vagrant/nanomsgxx/build/tests/test_message_ostream
    /home/vagrant/nanomsgxx/build/tests/test_pipeline
    /home/vagrant/nanomsgxx/build/tests/test_survey
    /home/vagrant/nanomsgxx/build/tests/test_message
    /home/vagrant/nanomsgxx/build/tests/test_reqrep_multi
    /home/vagrant/nanomsgxx/build/tests/test_poll
    /home/vagrant/nanomsgxx/build/tests/test_nnxx_ext
    /home/vagrant/nanomsgxx/build/tests/test_socket
    /home/vagrant/nanomsgxx/build/tests/test_pubsub
    /home/vagrant/nanomsgxx/build/tests/test_message_istream
    /home/vagrant/nanomsgxx/build/tests/test_timeout
  tests that fail 0/14
```

