### PR TITLE
Add enum for NN_RCVMAXSIZE and NN_MAXTTL

### DIFF
--- a/src/nnxx/socket.h
+++ b/src/nnxx/socket.h
@@ -53,6 +53,8 @@ namespace nnxx {
     SNDPRIO           = NN_SNDPRIO,
     IPV4ONLY          = NN_IPV4ONLY,
     SOCKET_NAME       = NN_SOCKET_NAME,
+    RCVMAXSIZE        = NN_RCVMAXSIZE,
+    MAXTTL            = NN_MAXTTL,
   };
 
   enum {


### PR DESCRIPTION
These values are added about two years ago.

https://github.com/nanomsg/nanomsg/blob/e91e2d18842d12a303586114d4c8f1fe10e9afc2/src/nn.h#L336

