### PR TITLE
Remove checks for libc++ in order to support c++11 features with non-libc++ stdlib implementations.

### DIFF
--- a/src/nnxx/message_istream.h
+++ b/src/nnxx/message_istream.h
@@ -48,11 +48,9 @@ namespace nnxx {
     ~basic_message_istream();
     basic_message_istream &operator=(basic_message_istream const &&) = delete;
 
-#if NNXX_LIBCPP
     basic_message_istream(basic_message_istream &&m) noexcept;
     basic_message_istream &operator=(basic_message_istream &&m) noexcept;
-    void swap(basic_message_istream &m) noexcept; 
-#endif // NNXX_LIBCPP
+    void swap(basic_message_istream &m) noexcept;
 
     void msg(message &&m) noexcept;
 
@@ -60,12 +58,10 @@ namespace nnxx {
     message_streambuf m_buffer;
   };
 
-#if NNXX_LIBCPP
   template < typename Char, typename Traits >
   void swap(basic_message_istream<Char, Traits> &m1,
             basic_message_istream<Char, Traits> &m2) noexcept
   { m1.swap(m2); }
-#endif // NNXX_LIBCPP
 
   typedef basic_message_istream<char> message_istream;
 

--- a/src/nnxx/message_istream.hpp
+++ b/src/nnxx/message_istream.hpp
@@ -28,7 +28,6 @@ namespace nnxx {
   void basic_message_istream<Char, Traits>::msg(message &&m) noexcept
   { m_buffer.msg(std::move(m)); }
 
-#if NNXX_LIBCPP
   template < typename Char, typename Traits >
   basic_message_istream<Char, Traits>::
   basic_message_istream(basic_message_istream &&m) noexcept:
@@ -56,7 +55,6 @@ namespace nnxx {
     base_type::swap(m);
     swap(m_buffer, m.m_buffer);
   }
-#endif // NNXX_LIBCPP
 
 }
 

--- a/src/nnxx/message_ostream.h
+++ b/src/nnxx/message_ostream.h
@@ -48,11 +48,9 @@ namespace nnxx {
     ~basic_message_ostream();
     basic_message_ostream &operator=(basic_message_ostream const &) = delete;
 
-#if NNXX_LIBCPP
     basic_message_ostream(basic_message_ostream &&m) noexcept;
     basic_message_ostream &operator=(basic_message_ostream &&m) noexcept;
-    void swap(basic_message_ostream &m) noexcept; 
-#endif // NNXX_LIBCPP
+    void swap(basic_message_ostream &m) noexcept;
 
     void    msg(message &&m) noexcept;
     message msg(int type = 0);
@@ -62,12 +60,10 @@ namespace nnxx {
     message_streambuf m_buffer;
   };
 
-#if NNXX_LIBCPP
   template < typename Char, typename Traits >
   void swap(basic_message_ostream<Char, Traits> &m1,
             basic_message_ostream<Char, Traits> &m2) noexcept
   { m1.swap(m2); }
-#endif // NNXX_LIBCPP
 
   typedef basic_message_ostream<char> message_ostream;
 

--- a/src/nnxx/message_ostream.hpp
+++ b/src/nnxx/message_ostream.hpp
@@ -36,7 +36,6 @@ namespace nnxx {
   message basic_message_ostream<Char, Traits>::move_msg()
   { return m_buffer.move_msg(); }
 
-#if NNXX_LIBCPP
   template < typename Char, typename Traits >
   basic_message_ostream<Char, Traits>::
   basic_message_ostream(basic_message_ostream &&m) noexcept:
@@ -64,7 +63,6 @@ namespace nnxx {
     base_type::swap(m);
     swap(m_buffer, m.m_buffer);
   }
-#endif // NNXX_LIBCPP
 
 }
 

--- a/src/nnxx/message_streambuf.h
+++ b/src/nnxx/message_streambuf.h
@@ -28,13 +28,6 @@
 #include <streambuf>
 #include <nnxx/message.h>
 
-// Detect usage of libc++
-#ifdef _LIBCPP_VERSION
-# define NNXX_LIBCPP 1
-#else
-# define NNXX_LIBCPP 0
-#endif // _LIBCPP_VERSION
-
 namespace nnxx {
 
   template < typename Char, typename Traits = std::char_traits<Char> >
@@ -56,11 +49,9 @@ namespace nnxx {
     ~basic_message_streambuf();
     basic_message_streambuf &operator=(basic_message_streambuf const &) = delete;
 
-#if NNXX_LIBCPP
     basic_message_streambuf(basic_message_streambuf &&m) noexcept;
     basic_message_streambuf &operator=(basic_message_streambuf &&m) noexcept;
     void swap(basic_message_streambuf &m) noexcept;
-#endif // NNXX_LIBCPP
 
     void msg(message &&m) noexcept;
     void clear() noexcept;

--- a/src/nnxx/message_streambuf.hpp
+++ b/src/nnxx/message_streambuf.hpp
@@ -121,7 +121,6 @@ namespace nnxx {
     return ~traits_type::eof();
   }
 
-#if NNXX_LIBCPP
   template < typename Char, typename Traits >
   basic_message_streambuf<Char, Traits>::
   basic_message_streambuf(basic_message_streambuf &&m) noexcept:
@@ -148,7 +147,6 @@ namespace nnxx {
     swap(m_base_size, m.m_base_size);
     swap(m_msg, m.m_msg);
   }
-#endif // NNXX_LIBCPP
 
 }
 


### PR DESCRIPTION
This change makes c++11 support required.

see https://github.com/achille-roussel/nanomsgxx/issues/16