### PR TITLE
Add CMake build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.5)
+
+set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+
+set(VERSION_MAJOR    0)
+set(VERSION_MINOR    1)
+set(VERSION_PATCH    0)
+set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+
+project(nanomsgxx VERSION ${VERSION})
+
+# project wide C++ options and include direcories:
+set (CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+enable_testing()
+
+add_subdirectory(src)
+add_subdirectory(tests)
+

--- a/README
+++ b/README
@@ -9,11 +9,14 @@ nanomsgxx is a binding of the nanomsg library for C++11.
 Building and installing
 -----------------------
 
+### Building and installing with waf
+
 nanomsgxx's build is driven by waf, you can get more information about
 what waf is and how it works [here](https://waf.io/book/).
 
 waf is packaged with nanomsgxx, all you should need is a python interpreter and
 running these commands:
+
 ```
 ./waf configure
 ./waf build
@@ -23,6 +26,45 @@ running these commands:
 The library and headers will be installed on your system and you'll be able to
 link your program against **libnanomsgxx**.
 
+### Building and installing with CMake
+
+nanomsgxx also supports CMake builds on various architectures (tested with Windows 10 + VisualStudio2017 and Ubuntu16.04 + g++/clang/c++).
+
+- install [CMake](https://cmake.org/) and a *CMake generator*, e.g. [GNU make](https://www.gnu.org/software/make/). See [here](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html) for a list of available CMake generators and how to use them.
+
+#### On Linux
+
+```bash
+mkdir -p build && cd $_
+
+# available build types: Debug, Release
+# install location may be adapted with -DCMAKE_INSTALL_PREFIX=path/to/install/nanomsgxx
+cmake -DCMAKE_BUILD_TYPE=Release ..
+
+# build example with GNU make
+make
+
+# run tests
+make test
+
+# install to default location (warning: uninstalling is not that easy)
+sudo make install
+sudo ldconfig
+
+```
+
+#### On Windows using Visual Studio 2017
+
+Since VisualStudio 2017 CMake is supported (see this [tutorial](https://blogs.msdn.microsoft.com/vcblog/2016/10/05/cmake-support-in-visual-studio/)).
+
+```cmd
+mkdir build
+cd build
+
+cmake -G "Visual Studio 15 2017" ..
+```
+
+This will generate a VisualStudio 2017 `nanomsgxx.sln` file in folder `build/`. Building project `ALL_BUILD` will build the whole solution. Building project `INSTALL` (with VS2017 started as administrator) will install the project.
 
 Getting started
 ---------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,67 @@
+project(nnxx)
+
+find_package(nanomsg CONFIG REQUIRED)
+
+IF(!nanomsg_FOUND)
+    IF (WIN32)
+    # This is not advanced yet, as it does not work for custom install locations.
+    # The general directory, however, is found by `find_package`.
+    # --> Throw an error, if nanomsg cannot be found
+        message(FATAL_ERROR "nanomsg library is required, but not found in standard location.")
+    ELSE()
+        # on UNIX platforms pkg_config can be used as fallback solution
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(nanomsg REQUIRED nanomsg)
+    ENDIF()
+ENDIF()
+
+
+set(NANOMSG_SRCS ./nanomsg/ext/nnxx_ext.c)
+
+set(NNXX_SRCS   ./nnxx/error.cpp
+                ./nnxx/message.cpp
+                ./nnxx/message_control.cpp
+                ./nnxx/message_istream.cpp
+                ./nnxx/message_iterator.cpp
+                ./nnxx/message_ostream.cpp
+                ./nnxx/message_streambuf.cpp
+                ./nnxx/nn.cpp
+                ./nnxx/poll.cpp
+                ./nnxx/pubsub.cpp
+                ./nnxx/reqrep.cpp
+                ./nnxx/socket.cpp
+                ./nnxx/survey.cpp
+                ./nnxx/tcp.cpp
+                ./nnxx/timeout.cpp)
+
+set(NNXX_HDRS   ./nanomsg/ext/nnxx_ext.h
+                ./nnxx/bus.h
+                ./nnxx/chrono.h
+                ./nnxx/error.h
+                ./nnxx/inproc.h
+                ./nnxx/ipc.h
+                ./nnxx/message.h
+                ./nnxx/message_control.h
+                ./nnxx/message_istream.h
+                ./nnxx/message_iterator.h
+                ./nnxx/message_ostream.h
+                ./nnxx/message_streambuf.h
+                ./nnxx/nn.h
+                ./nnxx/pair.h
+                ./nnxx/pipeline.h
+                ./nnxx/poll.h
+                ./nnxx/pubsub.h
+                ./nnxx/reqrep.h
+                ./nnxx/socket.h
+                ./nnxx/survey.h
+                ./nnxx/tcp.h
+                ./nnxx/timeout.h
+                ./nnxx/unittest.h)
+
+add_library(${PROJECT_NAME} ${NANOMSG_SRCS} ${NNXX_SRCS})
+add_library(lib::nnxx ALIAS ${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME} PUBLIC "." ${NANOMSG_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PUBLIC nanomsg)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+install(FILES ${NNXX_HDRS} DESTINATION include/nnxx)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,61 @@
+project(nnxx_tests)
+include(CTest)
+
+message(STATUS ${EXECUTABLE_OUTPUT_PATH})
+
+add_executable(test_message ./test_message.cpp)
+target_link_libraries(test_message nnxx)
+add_test(message ${EXECUTABLE_OUTPUT_PATH}/test_message)
+
+add_executable(test_message_istream ./test_message_istream.cpp)
+target_link_libraries(test_message_istream nnxx)
+add_test(message_istream ${EXECUTABLE_OUTPUT_PATH}/test_message_istream)
+
+add_executable(test_message_ostream ./test_message_ostream.cpp)
+target_link_libraries(test_message_ostream nnxx)
+add_test(message_ostream ${EXECUTABLE_OUTPUT_PATH}/test_message_ostream)
+
+add_executable(test_nnxx_ext ./test_nnxx_ext.cpp)
+target_link_libraries(test_nnxx_ext nnxx)
+add_test(nnxx_ext ${EXECUTABLE_OUTPUT_PATH}/test_nnxx_ext)
+
+add_executable(test_pair ./test_pair.cpp)
+target_link_libraries(test_pair nnxx)
+add_test(pair ${EXECUTABLE_OUTPUT_PATH}/test_pair)
+
+add_executable(test_pipeline ./test_pipeline.cpp)
+target_link_libraries(test_pipeline nnxx)
+add_test(pipeline ${EXECUTABLE_OUTPUT_PATH}/test_pipeline)
+
+add_executable(test_poll ./test_poll.cpp)
+target_link_libraries(test_poll nnxx)
+add_test(poll ${EXECUTABLE_OUTPUT_PATH}/test_poll)
+
+add_executable(test_pubsub ./test_pubsub.cpp)
+target_link_libraries(test_pubsub nnxx)
+add_test(pubsub ${EXECUTABLE_OUTPUT_PATH}/test_pubsub)
+
+add_executable(test_readme ./test_readme.cpp)
+target_link_libraries(test_readme nnxx)
+add_test(readme ${EXECUTABLE_OUTPUT_PATH}/test_readme)
+
+add_executable(test_reqrep ./test_reqrep.cpp)
+target_link_libraries(test_reqrep nnxx)
+add_test(reqrep ${EXECUTABLE_OUTPUT_PATH}/test_reqrep)
+
+add_executable(test_reqrep_multi ./test_reqrep_multi.cpp)
+target_link_libraries(test_reqrep_multi nnxx)
+add_test(reqrep_multi ${EXECUTABLE_OUTPUT_PATH}/test_reqrep_multi)
+
+add_executable(test_socket ./test_socket.cpp)
+target_link_libraries(test_socket nnxx)
+add_test(socket ${EXECUTABLE_OUTPUT_PATH}/test_socket)
+
+add_executable(test_survey ./test_survey.cpp)
+target_link_libraries(test_survey nnxx)
+add_test(survey ${EXECUTABLE_OUTPUT_PATH}/test_survey)
+
+add_executable(test_timeout ./test_timeout.cpp)
+target_link_libraries(test_timeout nnxx)
+add_test(timeout ${EXECUTABLE_OUTPUT_PATH}/test_timeout)
+


### PR DESCRIPTION
Files for building with CMake have been added. This enables to build with CMake on different Platforms (also on Windows with Visual Studio 2017) and to easier integrate this project into other CMake based projects.

This change includes:
- `CMakeLists.txt` files to allow CMake build
- Added section on *building and installing with CMake* on Windows and Linux in the `README` file.