### PR TITLE
[PkgConfig] Fix nanomsg requirement

### DIFF
--- a/libnnxx.pc.in
+++ b/libnnxx.pc.in
@@ -6,6 +6,6 @@ Name: Nanomsgxx
 Description: Nanomsg binding for C++11
 URL: https://github.com/achille-roussel/nanomsgxx
 Version: 0.1
-Requires: libnanomsg
+Requires: nanomsg
 Libs: -L${libdir} -lnnxx
 Cflags: -I${includedir}


### PR DESCRIPTION
`libnnxx.pc.in` required `libnanomsg`, but nanomsg exports a PkgConfig file
named `nanomsg.pc` (not `libnanomsg.pc`), so the requirement was not
met. See the [generating source](https://github.com/nanomsg/nanomsg/blob/master/src/CMakeLists.txt) (l. 370).