### PR TITLE
 Add CMake possibilities to include nanomsgxx in other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 
-set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
-set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
-set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+option (NNXX_STATIC_LIB "Build static library instead of shared library." OFF)
+option (NNXX_TESTS "Build and run tests for nanomsgxx." ON)
+
 
 set(VERSION_MAJOR    0)
 set(VERSION_MINOR    1)
@@ -16,8 +16,15 @@ set (CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-enable_testing()
+set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+
+
 
 add_subdirectory(src)
-add_subdirectory(tests)
+if(NNXX_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif(NNXX_TESTS)
 

--- a/README
+++ b/README
@@ -71,7 +71,7 @@ This will generate a VisualStudio 2017 `nanomsgxx.sln` file in folder `build/`. 
 - Via the exported CMake configuration:
 
   ```cmake
-  find_package(NANOMSGXX CONFIG REQUIRED)
+  find_package(nnxx CONFIG REQUIRED)
   ```
 
 - Via PkgConfig (Linux):
@@ -79,7 +79,7 @@ This will generate a VisualStudio 2017 `nanomsgxx.sln` file in folder `build/`. 
   ```cmake
   find_package(PkgConfig REQUIRED)
 
-  pkg_check_modules(NANOMSGXX REQUIRED libnnxx)
+  pkg_check_modules(nnxx REQUIRED libnnxx)
   
   ```
 
@@ -87,12 +87,12 @@ Both cases allow to use the following variables for including and linking:
 
 ```cmake
   # The following lines describe, which variables can be used
-  if (${NANOMSGXX_FOUND})
-  message(STATUS "nanomsgxx (v ${NANOMSGXX_VERSION}) found in '${NANOMSGXX_DIR}' with")
-  message(STATUS "include directories: ${NANOMSGXX_INCLUDE_DIRS}")
-  message(STATUS "libraries to link against: ${NANOMSGXX_LIBRARIES}")
+  if (${nnxx_FOUND})
+  message(STATUS "nanomsgxx (v ${nnxx_VERSION}) found in '${nnxx_DIR}' with")
+  message(STATUS "include directories: ${nnxx_INCLUDE_DIRS}")
+  message(STATUS "libraries to link against: ${nnxx_LIBRARIES}")
   message(STATUS "----------------------------------------")
-  endif(${NANOMSGXX_FOUND})
+  endif(${nnxx_FOUND})
 ```
 
 Getting started

--- a/README
+++ b/README
@@ -66,6 +66,35 @@ cmake -G "Visual Studio 15 2017" ..
 
 This will generate a VisualStudio 2017 `nanomsgxx.sln` file in folder `build/`. Building project `ALL_BUILD` will build the whole solution. Building project `INSTALL` (with VS2017 started as administrator) will install the project.
 
+#### Integrate nanomsgxx in your CMake project
+
+- Via the exported CMake configuration:
+
+  ```cmake
+  find_package(NANOMSGXX CONFIG REQUIRED)
+  ```
+
+- Via PkgConfig (Linux):
+
+  ```cmake
+  find_package(PkgConfig REQUIRED)
+
+  pkg_check_modules(NANOMSGXX REQUIRED libnnxx)
+  
+  ```
+
+Both cases allow to use the following variables for including and linking:
+
+```cmake
+  # The following lines describe, which variables can be used
+  if (${NANOMSGXX_FOUND})
+  message(STATUS "nanomsgxx (v ${NANOMSGXX_VERSION}) found in '${NANOMSGXX_DIR}' with")
+  message(STATUS "include directories: ${NANOMSGXX_INCLUDE_DIRS}")
+  message(STATUS "libraries to link against: ${NANOMSGXX_LIBRARIES}")
+  message(STATUS "----------------------------------------")
+  endif(${NANOMSGXX_FOUND})
+```
+
 Getting started
 ---------------
 

--- a/cmake/nnxx-config.cmake.in
+++ b/cmake/nnxx-config.cmake.in
@@ -1,0 +1,36 @@
+#  The MIT License (MIT)
+# 
+#  Copyright (c) 2014 Achille Roussel <achille.roussel@gmail.com>
+# 
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+# 
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+# 
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+ 
+@PACKAGE_INIT@
+
+### General variables for project discovery/inspection
+set_and_check(@PROJECT_NAME@_INSTALL_PREFIX @PACKAGE_CMAKE_INSTALL_PREFIX@)
+set_and_check(@PROJECT_NAME@_INCLUDE_DIRS @PACKAGE_CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@)
+set_and_check(@PROJECT_NAME@_LIBDIR @PACKAGE_CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@)
+set_and_check(@PROJECT_NAME@_CMAKE_DIR @PACKAGE_CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/cmake)
+
+### Import targets
+include(@PACKAGE_CMAKE_INSTALL_PREFIX@/@PACKAGE_INSTALL_DESTINATION@/@PROJECT_NAME@.cmake)
+
+check_required_components(@PROJECT_NAME@)
+
+set(@PROJECT_NAME@_LIBRARIES @PACKAGE_LINK_LIBRARIES@)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,10 @@ IF(!nanomsg_FOUND)
     ENDIF()
 ENDIF()
 
+set(CMAKE_INSTALL_BINDIR "bin")
+set(CMAKE_INSTALL_INCLUDEDIR "include")
+set(CMAKE_INSTALL_LIBDIR "lib")
+
 
 set(NANOMSG_SRCS ./nanomsg/ext/nnxx_ext.c)
 
@@ -34,8 +38,7 @@ set(NNXX_SRCS   ./nnxx/error.cpp
                 ./nnxx/tcp.cpp
                 ./nnxx/timeout.cpp)
 
-set(NNXX_HDRS   ./nanomsg/ext/nnxx_ext.h
-                ./nnxx/bus.h
+set(NNXX_HDRS   ./nnxx/bus.h
                 ./nnxx/chrono.h
                 ./nnxx/error.h
                 ./nnxx/inproc.h
@@ -56,12 +59,61 @@ set(NNXX_HDRS   ./nanomsg/ext/nnxx_ext.h
                 ./nnxx/survey.h
                 ./nnxx/tcp.h
                 ./nnxx/timeout.h
-                ./nnxx/unittest.h)
+                ./nnxx/unittest.h
+                ./nnxx/message_istream.hpp
+                ./nnxx/message_ostream.hpp
+                ./nnxx/message_streambuf.hpp
+                ./nnxx/socket.hpp)
 
-add_library(${PROJECT_NAME} ${NANOMSG_SRCS} ${NNXX_SRCS})
+if (NNXX_STATIC_LIB)
+    add_library(${PROJECT_NAME} STATIC ${NANOMSG_SRCS} ${NNXX_SRCS})
+    set(PACKAGE_LINK_LIBRARIES ${PROJECT_NAME})
+else()
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    add_library(${PROJECT_NAME} SHARED ${NANOMSG_SRCS} ${NNXX_SRCS})
+    set(PACKAGE_LINK_LIBRARIES ${PROJECT_NAME} nanomsg)
+    
+endif()
+
 add_library(lib::nnxx ALIAS ${PROJECT_NAME})
-target_include_directories(${PROJECT_NAME} PUBLIC "." ${NANOMSG_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PUBLIC nanomsg)
 
-install(TARGETS ${PROJECT_NAME} DESTINATION lib)
-install(FILES ${NNXX_HDRS} DESTINATION include/nnxx)
+target_include_directories(${PROJECT_NAME} PUBLIC   ${NANOMSG_INCLUDE_DIRS} 
+                                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                                                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+
+# Generate and install CMake package:
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES ${NNXX_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+
+include(CMakePackageConfigHelpers)
+set(PACKAGE_INSTALL_DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${VERSION}
+)
+install(EXPORT ${PROJECT_NAME}
+        DESTINATION ${PACKAGE_INSTALL_DESTINATION}
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    VERSION ${VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+configure_package_config_file(
+    ${CMAKE_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION ${PACKAGE_INSTALL_DESTINATION}
+    PATH_VARS CMAKE_INSTALL_PREFIX
+)
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    DESTINATION ${PACKAGE_INSTALL_DESTINATION}
+)
+
+# Generate and install PkgConfig file:
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+CONFIGURE_FILE("../libnnxx.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libnnxx.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libnnxx.pc" 
+        DESTINATION "${libdir}/pkgconfig")


### PR DESCRIPTION

- Add section in Readme describing how to import `nanomsgxx` in projects
- `nnxx-config.cmake` is exported to support `find_package(nnxx ...)`.
- PkgConfig support added, CMake now also parses `libnnxx.pc.in`
- Add options for turning off tests and switching between static/dynamic
library creation.